### PR TITLE
fix: nonmatching capture groups between capturing ones

### DIFF
--- a/src/bindings.ml
+++ b/src/bindings.ml
@@ -2,6 +2,10 @@ type jit = [ `JIT ]
 type interp = [ `Interp ]
 type 'a regex constraint 'a = [< jit | interp ]
 
+let unset = (-1, -1)
+(* Since -1 == PCRE2_UNSET.
+   TODO: obtain this value as part of the bindings, rather than like so *)
+
 external pcre2_ocaml_init : unit -> unit = "pcre2_ocaml_init"
 
 external pcre2_compile :

--- a/src/pcre2.ml
+++ b/src/pcre2.ml
@@ -31,8 +31,8 @@ module Match = struct
   let match_of_captures ((subject, matches, _) : captures) (i : int) :
       match_ option =
     if 0 <= i && i < Array.length matches then
-      let start, end_ = matches.(i) in
-      Some (subject, start, end_)
+      let ((start, end_) as match_) = matches.(i) in
+      if match_ = Bindings.unset then None else Some (subject, start, end_)
     else None
 
   let named_match_of_captures ((subject, matches, names) : captures)


### PR DESCRIPTION
When a capture group is not matched, but is between two that did, we
currently incorrectly give the range as `Some [-1, -1]`. This should
instead be `None`--i.e., no match. This was due to the fact that numbering
of capture groups is based on their order in the pattern text, but they
could be alternative or otherwise optional. For instance:

    (a)(b)?(c)
    (a)(?:(b)|(c))

In both above cases, the capture group `(b)` is number 2, but may not be
matched, either since it is optional or that case need not be taken.

To fix, we need to explicitly check that even if we're in bounds that
the capture group actually produced a match. See also `PCRE2_UNSET`,
`pcre2_match(3)`.

Test plan: additional coverage; `dune test`.