### PR TITLE
fix: include trailing content in `split`

### DIFF
--- a/src/pcre2.ml
+++ b/src/pcre2.ml
@@ -699,17 +699,28 @@ module Interp = struct
       | None -> delims
       | _ -> invalid_arg "todo: decide how to handle 0 or negative limit"
     in
-    Seq.fold_left
-      (fun x m ->
-        match (x, m) with
-        | Ok (start, acc), Ok m ->
-            let { start = delim_start; end_ = delim_end } = range_of_match m in
-            let sub = String.sub subject start (delim_start - start) in
-            Ok (delim_end, sub :: acc)
-        | e, _ -> e)
-      (Ok (0, []))
-      delims
-    |> Result.map snd |> Result.map List.rev
+    let* end_offset, substrings =
+      Seq.fold_left
+        (fun x m ->
+          match (x, m) with
+          | Ok (start, acc), Ok m ->
+              let { start = delim_start; end_ = delim_end } =
+                range_of_match m
+              in
+              let sub = String.sub subject start (delim_start - start) in
+              Ok (delim_end, sub :: acc)
+          | e, _ -> e)
+        (Ok (0, []))
+        delims
+    in
+    Ok
+      ((* We still have one more substring to add: the one after the last
+          delimiter. *)
+       String.(sub subject end_offset (length subject - end_offset))
+       :: substrings
+      (* ... and we built this in reverse to be fast---but let's return it in
+         the right order. *)
+      |> List.rev)
 
   let is_match ?(options : match_option list = []) ?(subject_offset : int = 0)
       (re : t) (subject : string) : (bool, match_error) Result.t =
@@ -805,17 +816,28 @@ module Jit = struct
       | None -> delims
       | _ -> invalid_arg "todo: decide how to handle 0 or negative limit"
     in
-    Seq.fold_left
-      (fun x m ->
-        match (x, m) with
-        | Ok (start, acc), Ok m ->
-            let { start = delim_start; end_ = delim_end } = range_of_match m in
-            let sub = String.sub subject start (delim_start - start) in
-            Ok (delim_end, sub :: acc)
-        | e, _ -> e)
-      (Ok (0, []))
-      delims
-    |> Result.map snd |> Result.map List.rev
+    let* end_offset, substrings =
+      Seq.fold_left
+        (fun x m ->
+          match (x, m) with
+          | Ok (start, acc), Ok m ->
+              let { start = delim_start; end_ = delim_end } =
+                range_of_match m
+              in
+              let sub = String.sub subject start (delim_start - start) in
+              Ok (delim_end, sub :: acc)
+          | e, _ -> e)
+        (Ok (0, []))
+        delims
+    in
+    Ok
+      ((* We still have one more substring to add: the one after the last
+          delimiter. *)
+       String.(sub subject end_offset (length subject - end_offset))
+       :: substrings
+      (* ... and we built this in reverse to be fast---but let's return it in
+         the right order. *)
+      |> List.rev)
 
   (* TODO(cooper): dedup impl with a functor? *)
   let is_match ?(options : match_option list = []) ?(subject_offset : int = 0)

--- a/test/pcre2_tests.ml
+++ b/test/pcre2_tests.ml
@@ -92,6 +92,16 @@ let bad_offset ctxt =
         assert_equal ~printer (Error BADOFFSET)
           (find ~subject_offset:10 re "123abc456" >+= range_of_match))
 
+let split_comma ctxt =
+  Interp.(
+    match compile "," with
+    | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
+    | Ok re ->
+        let printer = [%show: (string list, match_error) result] in
+        assert_equal ~printer (Ok [ "a"; "b"; "c" ]) (split re "a,b,c");
+        assert_equal ~printer (Ok [ "a"; "b"; "c"; "" ]) (split re "a,b,c,");
+        assert_equal ~printer (Ok [ "a"; "bc" ]) (split ~limit:1 re "a,b,c,"))
+
 let check_version ctxt =
   let major, minor = Pcre2.version in
   assert_equal ~printer:string_of_int 10 major;
@@ -101,8 +111,9 @@ let suite =
   "Test pcre"
   >::: [
          "simple_test" >:: simple_test;
-         "simple_test" >:: simple_captures;
+         "simple_captures" >:: simple_captures;
          "non_contiguous_capture" >:: non_contiguous_capture;
+         "split_comma" >:: split_comma;
          "bad_pattern" >:: bad_pattern;
          "bad_offset" >:: bad_offset;
          "version" >:: check_version;


### PR DESCRIPTION
Previously, `split` incorrectly dropped any content following the last
delimiter. For example, if you split `"a,b,c"` on `/,/`, then the resulting
list would be only `["a"; "b"]`. This fixes the implementation, so it
should now be `["a"; "b"; "c"]`.

Test plan: `dune runtest`; additional coverage.