### PR TITLE
feat: expose `range_of_captures`

### DIFF
--- a/src/intf.ml
+++ b/src/intf.ml
@@ -27,6 +27,10 @@ module type Matcher = sig
      have more variability. No need to generalize now, but useful if we add
      other engines like re2 or vectorscan *)
 
+  val range_of_captures : captures -> range
+  (** [range_of_captures c] is range of the matched text, providing the start
+      and end byte offsets. *)
+
   val captures_length : captures -> int
   (** [captures_length c] is the number of matches contained in [c]. *)
 

--- a/test/pcre2_tests.ml
+++ b/test/pcre2_tests.ml
@@ -39,7 +39,7 @@ let simple_captures ctxt =
         let c = captures re "abc" in
         assert_equal ~printer
           (Ok (Some { start = 0; end_ = 3 }))
-          (c >>= (fun c -> match_of_captures c 0) >+= range_of_match);
+          (c >+= range_of_captures);
         assert_equal ~printer
           (Ok (Some { start = 0; end_ = 1 }))
           (c >>= (fun c -> match_of_captures c 1) >+= range_of_match);


### PR DESCRIPTION
This was implemented internally. Now add it to the interface. This allows for getting the range of the entire capturing match without the need to unwrap the 0th match.