### PR TITLE
fix: update split docs & test for limit behaviour

### DIFF
--- a/src/intf.ml
+++ b/src/intf.ml
@@ -151,8 +151,8 @@ module type Matcher = sig
   (** [split re subject] is a list of substrings of [subject] obtained by
       splitting it by removing matches [re] generates. If [subject_offset] is
       provided, matching to determine where to split starts there instead of
-      the start of [subject]. If [limit] is provided then only the first
-      [limit] matches are considered for splitting.
+      the start of [subject]. If [limit] is provided then [subject] will be
+      split into at most that many substrings.
 
       If a matching error occurs during this process, [Error e] is returned.
     *)

--- a/test/pcre2_tests.ml
+++ b/test/pcre2_tests.ml
@@ -116,7 +116,7 @@ let split_comma ctxt =
         let printer = [%show: (string list, match_error) result] in
         assert_equal ~printer (Ok [ "a"; "b"; "c" ]) (split re "a,b,c");
         assert_equal ~printer (Ok [ "a"; "b"; "c"; "" ]) (split re "a,b,c,");
-        assert_equal ~printer (Ok [ "a"; "bc" ]) (split ~limit:1 re "a,b,c,"))
+        assert_equal ~printer (Ok [ "a"; "b,c," ]) (split ~limit:2 re "a,b,c,"))
 
 let check_version ctxt =
   let major, minor = Pcre2.version in
@@ -128,7 +128,7 @@ let suite =
   >::: [
          "simple_test" >:: simple_test;
          "simple_captures" >:: simple_captures;
-          "split_comma" >:: split_comma;
+         "split_comma" >:: split_comma;
          "non_contiguous_capture" >:: non_contiguous_capture;
          "non_contiguous_named_capture" >:: non_contiguous_named_capture;
          "bad_pattern" >:: bad_pattern;


### PR DESCRIPTION
Previously this was documented as the number of matches, rather than the number of substrings.