### PR TITLE
fix: ensure correct flag format

### DIFF
--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -10,5 +10,5 @@ let () =
         | Some pc ->
             Option.value (C.Pkg_config.query pc ~package:"libpcre2-8") ~default
       in
-      C.Flags.write_lines "c_flags.sexp" conf.cflags;
+      C.Flags.write_sexp "c_flags.sexp" conf.cflags;
       C.Flags.write_sexp "c_library_flags.sexp" conf.libs)


### PR DESCRIPTION
Make sure we write sexp if we want to ingest it as such.