### PR TITLE
fix: a few fatal bugs

### DIFF
--- a/src/pcre2_stubs.c
+++ b/src/pcre2_stubs.c
@@ -1,4 +1,3 @@
-#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/pcre2_stubs.c
+++ b/src/pcre2_stubs.c
@@ -534,7 +534,7 @@ CAMLprim value capture_unboxed(
 
 /// Boxed argument version of [capture_unboxed] (for bytecode).
 CAMLprim value capture(value *argv, int argc UNUSED) {
-        return match_unboxed(argv[0], argv[1], Nativeint_val(argv[2]), Int32_val(argv[3]));
+        return capture_unboxed(argv[0], argv[1], Nativeint_val(argv[2]), Int32_val(argv[3]));
 }
 
 /// Match, with capture groups, the provided JIT-enabled pattern.
@@ -642,5 +642,5 @@ CAMLprim value jit_capture_unboxed(
 
 /// Boxed argument version of [capture_unboxed] (for bytecode).
 CAMLprim value jit_capture(value *argv, int argc UNUSED) {
-        return match_unboxed(argv[0], argv[1], Nativeint_val(argv[2]), Int32_val(argv[3]));
+        return jit_capture_unboxed(argv[0], argv[1], Nativeint_val(argv[2]), Int32_val(argv[3]));
 }

--- a/src/pcre2_stubs.c
+++ b/src/pcre2_stubs.c
@@ -233,7 +233,7 @@ CAMLprim value jit_compile_unboxed(
                 // SAFETY: This allocation is immediately filled with
                 // well-formed values prior to returning.
                 result = caml_alloc_small(1, RESULT_ERROR_TAG);
-                Field(0, result) = Val_int(res);
+                Field(result, 0) = Val_int(res);
                 CAMLreturn(result);
         }
 
@@ -247,7 +247,7 @@ CAMLprim value jit_compile_unboxed(
         // call pcre2_jit_compile multiple times on the same pcer2_code*
         // safely. Since pcre2_match permits jit, and while {interp regex} is
         // "really" interpreted OR JIT, {jit regex} is definitely JIT.
-        Field(0, result) = ocaml_re;
+        Field(result, 0) = ocaml_re;
         CAMLreturn(result);
 }
 

--- a/src/pcre2_stubs.c
+++ b/src/pcre2_stubs.c
@@ -340,7 +340,7 @@ CAMLprim value jit_match_unboxed(value ocaml_re /* : jit regex */, value subject
         // SAFETY: This allocation is immediately filled with
         // well-formed values prior to returning.
         result = caml_alloc_small(1, RESULT_OK_TAG);
-        Field(result, 0) = range;
+        Field(result, 0) = match;
 
         CAMLreturn(result);
 }


### PR DESCRIPTION
Fixes three major bugs:
1. `capture` and `jit_capture` both called `match_unboxed`, rather than the appropriate `_unboxed` capturing function. A mismatch on return types here would cause a fatal error (typically a segfault).
2. Some uses of `Field` had the parameters flipped, so we would access a null pointer at some offset and try and set some value.
3. The return value in the successful case in `jit_match_unboxed` was incorrect. See 276df5d7b10c1f5acc51eeb91449b5bbf201f681 for details.

We need some additional test coverage. We don't have any for JIT presently, since I couldn't get it working. Once this is merged I'll commit some.