### PR TITLE
feat: add Matcher module type

### DIFF
--- a/src/pcre2.ml
+++ b/src/pcre2.ml
@@ -637,6 +637,8 @@ let config_depth_limit : int = -1
 (** Indicates use of stack recursion in matching function *)
 let config_stackrecurse : bool = true
 
+module type Matcher = Intf.Matcher
+
 module Interp = struct
   include Options.Interp
   include Match

--- a/src/pcre2.mli
+++ b/src/pcre2.mli
@@ -490,6 +490,9 @@ module Options : sig
   end
 end
 
+module type Matcher = Intf.Matcher
+(** Module type for matchers. *)
+
 module Interp : sig
   include module type of Options.Interp
 


### PR DESCRIPTION
This is useful for clients looking to write code which is generic over
both the interpeted and JIT implementations (like us in testing shortly).
