### PR TITLE
test: add tests for JIT

### DIFF
--- a/test/pcre2_tests.ml
+++ b/test/pcre2_tests.ml
@@ -13,8 +13,16 @@ let ( >>= ) x f =
   | Ok None -> Ok None
   | Error e -> Error e
 
-let simple_test ctxt =
-  Interp.(
+module MakeTests
+    (M :
+      Pcre2.Matcher
+        with type compile_error = compile_error
+         and type match_error = match_error) : sig
+  val tests : test list
+end = struct
+  open M
+
+  let simple_test ctxt =
     match compile "abc" with
     | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
     | Ok re ->
@@ -28,10 +36,9 @@ let simple_test ctxt =
         assert_equal ~printer
           (Ok (Some { start = 3; end_ = 6 }))
           (find re "123abc" >+= range_of_match);
-        assert_equal ~printer (Ok None) (find re "123ac" >+= range_of_match))
+        assert_equal ~printer (Ok None) (find re "123ac" >+= range_of_match)
 
-let simple_captures ctxt =
-  Interp.(
+  let simple_captures ctxt =
     match compile "(a)(b)(c)" with
     | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
     | Ok re ->
@@ -50,10 +57,9 @@ let simple_captures ctxt =
           (Ok (Some { start = 2; end_ = 3 }))
           (c >>= (fun c -> match_of_captures c 3) >+= range_of_match);
         assert_equal ~printer (Ok None)
-          (c >>= (fun c -> match_of_captures c 4) >+= range_of_match))
+          (c >>= (fun c -> match_of_captures c 4) >+= range_of_match)
 
-let non_contiguous_capture ctxt =
-  Interp.(
+  let non_contiguous_capture ctxt =
     match compile "(a)(?:(b)|(c))" with
     | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
     | Ok re ->
@@ -71,10 +77,9 @@ let non_contiguous_capture ctxt =
           (Ok (Some { start = 1; end_ = 2 }))
           (c >>= (fun c -> match_of_captures c 3) >+= range_of_match);
         assert_equal ~printer (Ok None)
-          (c >>= (fun c -> match_of_captures c 4) >+= range_of_match))
+          (c >>= (fun c -> match_of_captures c 4) >+= range_of_match)
 
-let non_contiguous_named_capture ctxt =
-  Interp.(
+  let non_contiguous_named_capture ctxt =
     match compile "(?<A>a)(?:(?<B>b)|(?<C>c))" with
     | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
     | Ok re ->
@@ -87,39 +92,35 @@ let non_contiguous_named_capture ctxt =
           (c >>= (fun c -> named_match_of_captures c "B") >+= range_of_match);
         assert_equal ~printer
           (Ok (Some { start = 1; end_ = 2 }))
-          (c >>= (fun c -> named_match_of_captures c "C") >+= range_of_match))
+          (c >>= (fun c -> named_match_of_captures c "C") >+= range_of_match)
 
-let bad_pattern ctxt =
-  Interp.(
+  let bad_pattern ctxt =
     match compile "ab(" with
     | Error MISSING_CLOSING_PARENTHESIS -> ()
     | Error e ->
         assert_failure ("Incorrectly error for pattern: " ^ show_compile_error e)
-    | Ok _ -> assert_failure "Incorrectly compiled invalid pattern")
+    | Ok _ -> assert_failure "Incorrectly compiled invalid pattern"
 
-let bad_offset ctxt =
-  Interp.(
+  let bad_offset ctxt =
     match compile "abc" with
     | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
     | Ok re ->
         let printer = [%show: (range option, match_error) result] in
-        assert_equal ~printer (Error BADOFFSET)
+        assert_equal ~printer ~msg:"Negative offset" (Error BADOFFSET)
           (find ~subject_offset:(-1) re "ab" >+= range_of_match);
-        assert_equal ~printer (Error BADOFFSET)
-          (find ~subject_offset:10 re "123abc456" >+= range_of_match))
+        assert_equal ~printer ~msg:"Offset too large" (Error BADOFFSET)
+          (find ~subject_offset:10 re "123abc456" >+= range_of_match)
 
-let split_comma ctxt =
-  Interp.(
+  let split_comma ctxt =
     match compile "," with
     | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
     | Ok re ->
         let printer = [%show: (string list, match_error) result] in
         assert_equal ~printer (Ok [ "a"; "b"; "c" ]) (split re "a,b,c");
         assert_equal ~printer (Ok [ "a"; "b"; "c"; "" ]) (split re "a,b,c,");
-        assert_equal ~printer (Ok [ "a"; "b,c," ]) (split ~limit:2 re "a,b,c,"))
+        assert_equal ~printer (Ok [ "a"; "b,c," ]) (split ~limit:2 re "a,b,c,")
 
-let capture_group_names ctxt =
-  Interp.(
+  let capture_group_names ctxt =
     (match compile "(?<A>a)(?<B>b)(?<C>c)" with
     | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
     | Ok re ->
@@ -133,23 +134,32 @@ let capture_group_names ctxt =
         assert_equal ~printer:[%show: (string * int) list]
           (* 0 is the whole match *)
           [ ("A", 1); ("C", 3) ]
-          (capture_groups re))
+          (capture_groups re)
+
+  let tests =
+    [
+      "simple_test" >:: simple_test;
+      "simple_captures" >:: simple_captures;
+      "split_comma" >:: split_comma;
+      "non_contiguous_capture" >:: non_contiguous_capture;
+      "non_contiguous_named_capture" >:: non_contiguous_named_capture;
+      "bad_pattern" >:: bad_pattern;
+      "bad_offset" >:: bad_offset;
+      "capture_group_names" >:: capture_group_names;
+    ]
+end
 
 let check_version ctxt =
   assert_bool "Version is older than newest tested" (Pcre2.version >= (10, 43))
 
 let suite =
+  let module Interp_Tests = MakeTests (Interp) in
+  let module Jit_Tests = MakeTests (Jit) in
   "Test pcre"
   >::: [
-         "simple_test" >:: simple_test;
-         "simple_captures" >:: simple_captures;
-         "split_comma" >:: split_comma;
-         "non_contiguous_capture" >:: non_contiguous_capture;
-         "non_contiguous_named_capture" >:: non_contiguous_named_capture;
-         "bad_pattern" >:: bad_pattern;
-         "bad_offset" >:: bad_offset;
          "version" >:: check_version;
-         "capture_group_names" >:: capture_group_names;
+         "Interp" >::: Interp_Tests.tests;
+         "JIT" >::: Jit_Tests.tests;
        ]
 
 let _ = if not !Sys.interactive then run_test_tt_main suite else ()


### PR DESCRIPTION
This refactors the tests to have any which should hold for either the
interperted or JIT implementation be generated by a functor parameterised over
the matching implementation.

Test plan: `dune runtest`.
