### PR TITLE
refactor: use pcre2_jit_match for jit_capture_unboxed

### DIFF
--- a/src/pcre2_stubs.c
+++ b/src/pcre2_stubs.c
@@ -584,8 +584,9 @@ CAMLprim value jit_capture_unboxed(
         // full match.
         // SAFETY: Passing in the value of String_val(subject) here is fine
         // since a GC cannot occur.
-        int num_captures = pcre2_match(re, (PCRE2_SPTR)String_val(subject), subject_length, offset,
-                                       options, match_data, mcontext);
+        // TODO: Compare notes on using pcre2_jit_match in jit_match_unboxed.
+        int num_captures = pcre2_jit_match(re, (PCRE2_SPTR)String_val(subject), subject_length,
+                                           offset, options, match_data, mcontext);
         PCRE2_SIZE *ovec = pcre2_get_ovector_pointer(match_data);
 
         if (num_captures == PCRE2_ERROR_NOMATCH || num_captures == PCRE2_ERROR_PARTIAL) {


### PR DESCRIPTION
This is for consistency with `jit_match_unboxed`. Both implementations
still require some additional checks for safety. See the comment in
`jit_match_unboxed`.