### PR TITLE
test: more tests

### DIFF
--- a/test/pcre2_tests.ml
+++ b/test/pcre2_tests.ml
@@ -136,6 +136,68 @@ end = struct
           [ ("A", 1); ("C", 3) ]
           (capture_groups re)
 
+  let find_iter_test ctxt =
+    match compile "a+" with
+    | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
+    | Ok re ->
+        let results = find_iter re "aaa bb aaaa cc a" |> List.of_seq in
+        let printer = [%show: (range, match_error) result list] in
+        assert_equal ~printer
+          [
+            Ok { start = 0; end_ = 3 };
+            Ok { start = 7; end_ = 11 };
+            Ok { start = 15; end_ = 16 };
+          ]
+          (List.map (Result.map range_of_match) results)
+
+  let find_iter_empty ctxt =
+    match compile "x+" with
+    | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
+    | Ok re ->
+        let results = find_iter re "aaa bb aaaa cc a" |> List.of_seq in
+        assert_equal ~printer:[%show: (range, match_error) result list] []
+          (List.map (Result.map range_of_match) results)
+
+  let find_iter_with_offset ctxt =
+    match compile "a+" with
+    | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
+    | Ok re ->
+        let results =
+          find_iter ~subject_offset:5 re "aaa bb aaaa cc a" |> List.of_seq
+        in
+        let printer = [%show: (range, match_error) result list] in
+        assert_equal ~printer
+          [ Ok { start = 7; end_ = 11 }; Ok { start = 15; end_ = 16 } ]
+          (List.map (Result.map range_of_match) results)
+
+  let captures_iter_test ctxt =
+    match compile "(a+)" with
+    | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
+    | Ok re ->
+        let results = captures_iter re "aaa bb aaaa cc a" |> List.of_seq in
+        let get_whole_and_first c =
+          match c with
+          | Ok c ->
+              let whole = range_of_captures c in
+              let first =
+                match match_of_captures c 1 with
+                | Some m -> Some (range_of_match m)
+                | None -> None
+              in
+              Ok (whole, first)
+          | Error e -> Error e
+        in
+        let printer =
+          [%show: (range * range option, match_error) result list]
+        in
+        assert_equal ~printer
+          [
+            Ok ({ start = 0; end_ = 3 }, Some { start = 0; end_ = 3 });
+            Ok ({ start = 7; end_ = 11 }, Some { start = 7; end_ = 11 });
+            Ok ({ start = 15; end_ = 16 }, Some { start = 15; end_ = 16 });
+          ]
+          (List.map get_whole_and_first results)
+
   let tests =
     [
       "simple_test" >:: simple_test;
@@ -146,6 +208,10 @@ end = struct
       "bad_pattern" >:: bad_pattern;
       "bad_offset" >:: bad_offset;
       "capture_group_names" >:: capture_group_names;
+      "find_iter" >:: find_iter_test;
+      "find_iter_empty" >:: find_iter_empty;
+      "find_iter_with_offset" >:: find_iter_with_offset;
+      "captures_iter" >:: captures_iter_test;
     ]
 end
 

--- a/test/pcre2_tests.ml
+++ b/test/pcre2_tests.ml
@@ -198,6 +198,57 @@ end = struct
           ]
           (List.map get_whole_and_first results)
 
+  let is_match_test ctxt =
+    match compile "a+" with
+    | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
+    | Ok re ->
+        let printer = [%show: (bool, match_error) result] in
+        assert_equal ~printer (Ok true) (is_match re "aaa bb");
+        assert_equal ~printer (Ok false) (is_match re "bbb cc");
+        assert_equal ~printer (Ok true)
+          (is_match ~subject_offset:7 re "bbb cc aaaa");
+        assert_equal ~printer (Ok false)
+          (is_match ~subject_offset:11 re "bbb cc aaaa")
+
+  let substring_of_match_test ctxt =
+    match compile "a+" with
+    | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
+    | Ok re -> (
+        (match find re "bbb aaa ccc" with
+        | Ok (Some m) ->
+            assert_equal ~printer:[%show: string] "aaa" (substring_of_match m)
+        | Ok None -> assert_failure "Expected to find a match"
+        | Error e -> assert_failure ("Match error: " ^ show_match_error e));
+        match find re "bbb ccc" with
+        | Ok None -> () (* Expected *)
+        | Ok (Some _) -> assert_failure "Unexpected match found"
+        | Error e -> assert_failure ("Match error: " ^ show_match_error e))
+
+  let captures_length_test ctxt =
+    match compile "(a+)(b+)(c+)" with
+    | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
+    | Ok re -> (
+        (match captures re "aaabbbccc" with
+        | Ok (Some c) ->
+            assert_equal ~printer:[%show: int] 4 (captures_length c)
+            (* whole match + 3 groups *)
+        | Ok None -> assert_failure "Expected to find captures"
+        | Error e -> assert_failure ("Match error: " ^ show_match_error e));
+        (* NB: here, the second capture group is optional *)
+        match compile "(a+)(b+)?(c+)" with
+        | Error e ->
+            assert_failure ("failed to compile: " ^ show_compile_error e)
+        | Ok re -> (
+            match captures re "aaaccc" with
+            | Ok (Some c) ->
+                assert_equal ~printer:[%show: int] 4 (captures_length c);
+                (* still 4, even with unmatched group *)
+                let m = match_of_captures c 2 in
+                assert_equal ~printer:[%show: range option] None
+                  (Option.map range_of_match m)
+            | Ok None -> assert_failure "Expected to find captures"
+            | Error e -> assert_failure ("Match error: " ^ show_match_error e)))
+
   let tests =
     [
       "simple_test" >:: simple_test;
@@ -212,6 +263,9 @@ end = struct
       "find_iter_empty" >:: find_iter_empty;
       "find_iter_with_offset" >:: find_iter_with_offset;
       "captures_iter" >:: captures_iter_test;
+      "is_match" >:: is_match_test;
+      "substring_of_match" >:: substring_of_match_test;
+      "captures_length" >:: captures_length_test;
     ]
 end
 

--- a/test/pcre2_tests.ml
+++ b/test/pcre2_tests.ml
@@ -249,6 +249,33 @@ end = struct
             | Ok None -> assert_failure "Expected to find captures"
             | Error e -> assert_failure ("Match error: " ^ show_match_error e)))
 
+  let split_advanced_test ctxt =
+    match compile {|\s+|} with
+    | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
+    | Ok re ->
+        let printer = [%show: (string list, match_error) result] in
+        assert_equal ~printer
+          (Ok [ "hello"; "world"; "test" ])
+          (split re "hello   world\t\ntest");
+        assert_equal ~printer
+          (Ok [ ""; "hello"; "world"; "" ])
+          (split re " hello world ");
+        assert_equal ~printer
+          (Ok [ "hello"; "world\t\ntest" ])
+          (split ~limit:2 re "hello   world\t\ntest")
+
+  let split_with_offset_test ctxt =
+    match compile "," with
+    | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
+    | Ok re ->
+        let printer = [%show: (string list, match_error) result] in
+        assert_equal ~printer
+          (Ok [ "a,b"; "c"; "d" ])
+          (split ~subject_offset:2 re "a,b,c,d");
+        assert_equal ~printer
+          (Ok [ "a,b,c"; "d" ])
+          (split ~subject_offset:4 re "a,b,c,d")
+
   let tests =
     [
       "simple_test" >:: simple_test;
@@ -266,6 +293,8 @@ end = struct
       "is_match" >:: is_match_test;
       "substring_of_match" >:: substring_of_match_test;
       "captures_length" >:: captures_length_test;
+      "split_advanced" >:: split_advanced_test;
+      "split_with_offset" >:: split_with_offset_test;
     ]
 end
 

--- a/test/pcre2_tests.ml
+++ b/test/pcre2_tests.ml
@@ -276,6 +276,45 @@ end = struct
           (Ok [ "a,b,c"; "d" ])
           (split ~subject_offset:4 re "a,b,c,d")
 
+  let empty_pattern_test ctxt =
+    match compile "" with
+    | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
+    | Ok re ->
+        let printer = [%show: (range option, match_error) result] in
+        (* Empty pattern matches at every position *)
+        assert_equal ~printer
+          (Ok (Some { start = 0; end_ = 0 }))
+          (find re "abc" >+= range_of_match);
+        (* Test that is_match works with empty patterns *)
+        let bool_printer = [%show: (bool, match_error) result] in
+        assert_equal ~printer:bool_printer (Ok true) (is_match re "abc");
+        assert_equal ~printer:bool_printer (Ok true) (is_match re "")
+
+  let unicode_test ctxt =
+    match compile "café" with
+    | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
+    | Ok re -> (
+        let printer = [%show: (range option, match_error) result] in
+        assert_equal ~printer
+          (Ok (Some { start = 0; end_ = 5 })) (* café is 5 bytes in UTF-8 *)
+          (find re "café" >+= range_of_match);
+        match find re "café" with
+        | Ok (Some m) ->
+            assert_equal ~printer:[%show: string] "café" (substring_of_match m)
+        | Ok None -> assert_failure "Expected to find a match"
+        | Error e -> assert_failure ("Match error: " ^ show_match_error e))
+
+  let overlapping_matches_test ctxt =
+    match compile "aa" with
+    | Error e -> assert_failure ("failed to compile: " ^ show_compile_error e)
+    | Ok re ->
+        let results = find_iter re "aaaa" |> List.of_seq in
+        let printer = [%show: (range, match_error) result list] in
+        (* Should find non-overlapping matches *)
+        assert_equal ~printer
+          [ Ok { start = 0; end_ = 2 }; Ok { start = 2; end_ = 4 } ]
+          (List.map (Result.map range_of_match) results)
+
   let tests =
     [
       "simple_test" >:: simple_test;
@@ -295,6 +334,9 @@ end = struct
       "captures_length" >:: captures_length_test;
       "split_advanced" >:: split_advanced_test;
       "split_with_offset" >:: split_with_offset_test;
+      "empty_pattern" >:: empty_pattern_test;
+      "unicode" >:: unicode_test;
+      "overlapping_matches" >:: overlapping_matches_test;
     ]
 end
 


### PR DESCRIPTION
Increases test coverage. Adds more testing for:
- `find_iter`
- `captures_iter`
- `is_match`
- `substring_of_match`
- `match_of_captures`,
- `captures_length`
- `split`

and some other cases, like empty patterns and unicode.
